### PR TITLE
omit embedded structs with inline tag

### DIFF
--- a/hack/docgen/main.go
+++ b/hack/docgen/main.go
@@ -315,22 +315,27 @@ func collectFields(s *structType) (fields []*Field) {
 			}
 		}
 
-		if f.Doc == nil {
-			log.Fatalf("field %q is missing a documentation", f.Names[0].Name)
-		}
-
 		if strings.Contains(f.Doc.Text(), "docgen:nodoc") {
 			continue
 		}
-
-		name := f.Names[0].Name
 
 		fieldType := formatFieldType(f.Type)
 		fieldTypeRef := getFieldType(f.Type)
 
 		tag := reflect.StructTag(strings.Trim(f.Tag.Value, "`"))
 		yamlTag := tag.Get("yaml")
+
+		if yamlTag == ",inline" {
+			// This is an embedded struct.
+			continue
+		}
+
 		yamlTag = strings.Split(yamlTag, ",")[0]
+
+		if f.Doc == nil {
+			log.Fatalf("field %q is missing a documentation", f.Names[0].Name)
+		}
+		name := f.Names[0].Name
 
 		if yamlTag == "" {
 			yamlTag = strings.ToLower(yamlTag)

--- a/hack/docgen/main.go
+++ b/hack/docgen/main.go
@@ -326,7 +326,8 @@ func collectFields(s *structType) (fields []*Field) {
 		yamlTag := tag.Get("yaml")
 
 		if yamlTag == ",inline" {
-			// This is an embedded struct.
+			// This is an inline embedded struct, add void field to maintain fields numers.
+			fields = append(fields, &Field{Text: &Text{}})
 			continue
 		}
 


### PR DESCRIPTION
# Pull Request


## Note to the Contributor

Added support for `,inline` [tag](https://pkg.go.dev/gopkg.in/yaml.v3#Marshal) to inline embedded structs.

Without the change, docgen tries to read the tag and crashes.
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.collectFields(0x612bc0)
	/go/pkg/mod/github.com/cloudentity/talos/hack/docgen@v0.0.0-20210428112812-63cd151f354b/main.go:319 +0x47c
main.main()
	/go/pkg/mod/github.com/cloudentity/talos/hack/docgen@v0.0.0-20210428112812-63cd151f354b/main.go:426 +0x594
```
